### PR TITLE
docs(ui-5): fix broken syntax highlighting

### DIFF
--- a/_posts/2020-05-28-ui-5.md
+++ b/_posts/2020-05-28-ui-5.md
@@ -16,7 +16,7 @@ If there's anything you've missed in this post, or encountered whilst upgrading,
 
 Since `@dhis2/ui` now bundles all our ui libraries, you can now import everything that you imported previously from `ui-core`, `ui-widgets` and `ui-forms` directly from `@dhis2/ui`. An example:
 
-```js
+```javascript
 // Before ui version 5:
 import { Button } from '@dhis2/ui-core'
 import { HeaderBar } from '@dhis2/ui-widgets'
@@ -35,10 +35,12 @@ We've added a notice box component. A notice box highlights useful information t
 See the [design specs](https://github.com/dhis2/design-system/blob/master/molecules/notice-box.md) for more information about the component. As an example, this is how you could use the NoticeBox to display a warning to a user:
 
 ```jsx
-<Noticebox warning title="Possible duplicate of another entry">
-    This entry has been marked as a duplicate. This should be fixed by an admin.
-    <a href="https://link.to">Further explanation</a>
-</Noticebox>
+const Warning = () => (
+    <Noticebox warning title="Possible duplicate of another entry">
+        This entry has been marked as a duplicate. This should be fixed by an admin.
+        <a href="https://link.to">Further explanation</a>
+    </Noticebox>
+)
 ```
 
 ## Specifying selected options
@@ -51,20 +53,22 @@ As noted above, instead of accepting an array of objects for the `selected` prop
 
 ```jsx
 // Before ui version 5:
-<Transfer
-    selected={[
-        { label: 'label 1', value: 'value 1' }
-    ]}
-    // ... other props
-/>
+const Old = () => (
+    <Transfer
+        selected={[
+            { label: 'label 1', value: 'value 1' }
+        ]}
+    />
+)
 
 // With ui version 5:
-<Transfer
-    selected={[
-        'value 1' // This should match the value of an existing option
-    ]}
-    // ... other props
-/>
+const New = () => (
+    <Transfer
+        selected={[
+            'value 1' // This should match the value of an existing option
+        ]}
+    />
+)
 ```
 
 ### SingleSelect and MultiSelect
@@ -73,30 +77,34 @@ Just like the `Transfer`, the `SingleSelect` and `MultiSelect` now also expect s
 
 ```jsx
 // Before ui version 5:
-<SingleSelect
-    selected={
-        { label: 'label 1', value: 'value 1' }
-    }
-    // ... other props
-/>
-<MultiSelect
-    selected={[
-        { label: 'label 1', value: 'value 1' }
-    ]}
-    // ... other props
-/>
+const OldSingle = () => (
+    <SingleSelect
+        selected={
+            { label: 'label 1', value: 'value 1' }
+        }
+    />
+)
+const OldMulti = () => (
+    <MultiSelect
+        selected={[
+            { label: 'label 1', value: 'value 1' }
+        ]}
+    />
+)
 
 // With ui version 5:
-<SingleSelect
-    selected="value 1"
-    // ... other props
-/>
-<MultiSelect
-    selected={[
-        'value 1'
-    ]}
-    // ... other props
-/>
+const NewSingle = () => (
+    <SingleSelect
+        selected="value 1"
+    />
+)
+const NewMulti = () => (
+    <MultiSelect
+        selected={[
+            'value 1'
+        ]}
+    />
+)
 ```
 
 Note that the `SingleSelect` expects a single string, and the `MultiSelect` an array of strings.
@@ -109,46 +117,48 @@ The Transfer now expects options to be passed to an `options` prop instead of as
 
 ```jsx
 // Before ui version 5:
-<Transfer
-    // ... other props
->
-    <TransferOption
-        label="label 1"
-        value="value 1"
-    />
-    <TransferOption
-        label="label 2"
-        value="value 2"
-    />
-</Transfer>
+const Old = () => (
+    <Transfer>
+        <TransferOption
+            label="label 1"
+            value="value 1"
+        />
+        <TransferOption
+            label="label 2"
+            value="value 2"
+        />
+    </Transfer>
+)
 
 // With ui version 5:
-<Transfer
-    options={[
-        { label: 'label 1', value: 'value 1' },
-        { label: 'label 2', value: 'value 2' }
-    ]}
-    // ... other props
-/>
+const New = () => (
+    <Transfer
+        options={[
+            { label: 'label 1', value: 'value 1' },
+            { label: 'label 2', value: 'value 2' }
+        ]}
+    />
+)
 ```
 
 If you want to use a custom option component, you can still do so. The `Transfer` accepts a `renderOption` prop, where you can supply a callback that returns the markup for a custom option. This pattern is called the render prop pattern, see the [React docs](https://reactjs.org/docs/render-props.html) for further information. An illustration of how this works:
 
 ```jsx
-<Transfer
-    options={[
-        { label: 'label 1', value: 'value 1' },
-        { label: 'label 2', value: 'value 2' },
-    ]}
-    renderOption={({ value, label, onClick, onDoubleClick, highlighted }) => (
-        <div onClick={onClick} onDoubleClick={onDoubleClick}>
-            The value of this option is: {value}
-            The label of this option is: {label}
-            {highlighted && 'This option is highlighted'}
-        </div>
-    )}
-    // ... other props
-/>
+const WithCustomOptions = () => (
+    <Transfer
+        options={[
+            { label: 'label 1', value: 'value 1' },
+            { label: 'label 2', value: 'value 2' },
+        ]}
+        renderOption={({ value, label, onClick, onDoubleClick, highlighted }) => (
+            <div onClick={onClick} onDoubleClick={onDoubleClick}>
+                The value of this option is: {value}
+                The label of this option is: {label}
+                {highlighted && 'This option is highlighted'}
+            </div>
+        )}
+    />
+)
 ```
 
 ## Layering components
@@ -162,10 +172,14 @@ More specifically, `Layer` and `CenteredContent` have been introduced to replace
 `Layer` is an overlay component that fills the entire viewport and allows you to stack various components on top of one another. The `Layer` accepts an `onClick` callback, so you can catch clicks on the background of whatever you're rendering. It also has a `translucent` prop, if you want the `Layer` to darken the background slightly (the default is fully transparent). An example:
 
 ```jsx
-<Layer>
-    <p>This will be rendered on top of the app, regardless of where you place it in your markup</p>
-</Layer>
-<p>Text behind the layer</p>
+const LayerExample = () => (
+    <div>
+        <Layer>
+            <p>This will be rendered on top of the app, regardless of where you place it in your markup</p>
+        </Layer>
+        <p>Text behind the layer</p>
+    </div>
+)
 ```
 
 The `Layer` uses React context internally to control the stacking logic. This context has been exposed via the `useLayerContext` hook, which can be used to append portals to the current layer-node, for advanced users.
@@ -176,14 +190,16 @@ The `ComponentCover` is similar to the `Layer`, except `ComponentCover` only fil
 
 {% raw %}
 ```jsx
-<div style={{ position: 'relative' }}>
-    <ComponentCover>
-        <p>
-            The ComponentCover will fill the parent div, and render this
-            paragraph on top of the div visually.
-        </p>
-    </ComponentCover>
-</div>
+const ComponentCoverExample = () => (
+    <div style={{ position: 'relative' }}>
+        <ComponentCover>
+            <p>
+                The ComponentCover will fill the parent div,
+                and render this paragraph on top of the div visually.
+            </p>
+        </ComponentCover>
+    </div>
+)
 ```
 {% endraw %}
 
@@ -192,12 +208,14 @@ The `ComponentCover` is similar to the `Layer`, except `ComponentCover` only fil
 `CenteredContent` is a component that centers its children. It has a `position` prop which can be used to vertically align the children at the `top`, `middle` (default), or `bottom`. It can be useful when you want to render a loading spinner on top of your app for example:
 
 ```jsx
-// This will render a spinner on top of your app, centered in the middle:
-<Layer>
-    <CenteredContent>
-        <CircularLoader />
-    </CenteredContent>
-</Layer>
+// This will render a spinner on top of your app, centered in the middle
+const Loading = () => (
+    <Layer>
+        <CenteredContent>
+            <CircularLoader />
+        </CenteredContent>
+    </Layer>
+)
 ```
 
 ## Click based Menu
@@ -212,16 +230,20 @@ The original `Menu` component has been renamed to `FlyoutMenu`, which will rende
 
 ```jsx
 // So this will render full-width
-<Menu>
-    <MenuItem label="Item 1" />
-    <MenuItem label="Item 2" />
-</Menu>
+const FullWidthMenu = () => (
+    <Menu>
+        <MenuItem label="Item 1" />
+        <MenuItem label="Item 2" />
+    </Menu>
+)
 
 // And this will render in a Card with width/height restrictions
-<FlyoutMenu>
-    <MenuItem label="Item 1" />
-    <MenuItem label="Item 2" />
-</FlyoutMenu>
+const CardMenu = () => (
+    <FlyoutMenu>
+        <MenuItem label="Item 1" />
+        <MenuItem label="Item 2" />
+    </FlyoutMenu>
+)
 ```
 
 ### MenuDivider and MenuSectionHeader
@@ -229,14 +251,16 @@ The original `Menu` component has been renamed to `FlyoutMenu`, which will rende
 We've also introduced two new components, the `MenuDivider` and `MenuSectionHeader`. As you would expect, the `MenuDivider` renders a divider between `MenuItems`. The `MenuSectionHeader` can be used to render a header in between menu-items. For example:
 
 ```jsx
-<Menu>
-    <MenuSectionHeader label="The header" />
-    <MenuItem label="Item 1" />
-    <MenuItem label="Item 2" />
-    <MenuDivider />
-    <MenuItem label="Item 3" />
-    <MenuItem label="Item 4" />
-</Menu>
+const WithHeaderAndDivider = () => (
+    <Menu>
+        <MenuSectionHeader label="The header" />
+        <MenuItem label="Item 1" />
+        <MenuItem label="Item 2" />
+        <MenuDivider />
+        <MenuItem label="Item 3" />
+        <MenuItem label="Item 4" />
+    </Menu>
+)
 ```
 
 ### Submenus
@@ -244,17 +268,19 @@ We've also introduced two new components, the `MenuDivider` and `MenuSectionHead
 Finally, to create sub-menus, you can now add MenuItems directly under a parent MenuItem, there's no need to wrap them in another component anymore:
 
 ```jsx
-<FlyoutMenu>
-    <MenuItem label="Item 1" />
-    <MenuItem label="Item 2">
-        <MenuItem label="Item 2 a" />
-        <MenuItem label="Item 2 b">
-            <MenuItem label="Item 2 b i" />
-            <MenuItem label="Item 2 b ii" />
+const WithSubMenus = () => (
+    <FlyoutMenu>
+        <MenuItem label="Item 1" />
+        <MenuItem label="Item 2">
+            <MenuItem label="Item 2 a" />
+            <MenuItem label="Item 2 b">
+                <MenuItem label="Item 2 b i" />
+                <MenuItem label="Item 2 b ii" />
+            </MenuItem>
+            <MenuItem label="Item 2 c" />
         </MenuItem>
-        <MenuItem label="Item 2 c" />
-    </MenuItem>
-</FlyoutMenu>
+    </FlyoutMenu>
+)
 ```
 
 ## Form components
@@ -320,17 +346,14 @@ const Fields = () => (
         <Field
             type="radio"
             component={RadioFieldFF}
-            // other props
         />
         <Field
             type="checkbox"
             component={CheckboxFieldFF}
-            // other props
         />
         <Field
             type="checkbox"
             component={SwitchFieldFF}
-            // other props
         />
     </div>
 )
@@ -477,20 +500,17 @@ const RadioButtons = () => (
         name="monster"
         label="The label for this group"
         required
-        // other props
     >
         <Legend>Choose your favourite monster</Legend>
         <Field
             name="monster"
             type="radio"
             component={RadioFieldFF}
-            // other props
         />
         <Field
             name="monster"
             type="radio"
             component={RadioFieldFF}
-            // other props
         />
     </FieldGroup>
 )


### PR DESCRIPTION
This fixes the broken jsx syntax highlighting. Apparently the parser (Rouge, https://github.com/rouge-ruby/rouge) has trouble highlighting inline jsx.

I've also removed the `other props` comments, as I don't feel like they were adding much value, and mostly cluttering up the examples.