### PR TITLE
docs(ui): update after ui 5 release

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -13,8 +13,7 @@ layout: page
     </ul>
     <h3>Component & Helper Libraries</h3>
     <ul>
-        <li><a href="https://ui-core.dhis2.nu">UI Core</a> - design primitives implementing the <a href="https://github.com/dhis2/design-system">Design System</a></li>
-        <li><a href="https://ui-widgets.dhis2.nu">UI Widgets</a> - large "organism"-level smart components for DHIS2 functionality</li>
+        <li><a href="https://ui.dhis2.nu">DHIS2 UI</a> - components and related resources for the DHIS2 <a href="https://github.com/dhis2/design-system">design system</a></li>
         <li><a href="https://github.com/dhis2/analytics">analytics</a> - helper functions and common components for analytics applications</li>
     </ul>
     <h3>API Reference</h3>
@@ -25,14 +24,13 @@ layout: page
     <ul>
         <li><a href="https://cli.dhis2.nu">d2</a> - command-line interface for DHIS2 development</li>
         <li><a href="https://cli-style.dhis2.nu">d2-style</a> - standardized code and commit style enforcement</li>
-        <!-- <li><a href="https://cli-utils-cypress.dhis2.nu">d2-utils-cypress</a> - boilerplate wrapper for Cypress integration and end-to-end testing</li> -->
         <li><a href="https://cli-utils-docsite.dhis2.nu">d2-utils-docsite</a> - generate a documentation website with consistent structure and design</li>
     </ul>
     <h3>Legacy libraries</h3>
-    <p>These libraries still receive maintenance support, but will be deprecated at the end of 2020.  They should be used sparingly in modern DHIS2 applications.</p>
+    <p>These libraries still receive maintenance support, but will be deprecated at the end of 2020. They should be used sparingly in modern DHIS2 applications.</p>
     <ul>
-        <li><a href="https://github.com/dhis2/d2-ui">d2-ui</a> - will be superceded by <a href="https://ui-widgets.dhis2.nu">UI Widgets</a></li>
         <li><a href="https://github.com/dhis2/d2-i18n">d2-i18n</a> - will be superceded by the <a href="https://runtime.dhis2.nu">App Runtime</a></li>
+        <li><a href="https://github.com/dhis2/d2-ui">d2-ui</a> - <strong>DEPRECATED</strong>, use <a href="https://ui.dhis2.nu">DHIS2 UI</a> instead</li>
         <li><a href="https://github.com/dhis2/d2">d2</a> - <strong>DEPRECATED</strong>, use <a href="https://runtime.dhis2.nu">App Runtime</a> instead</li>
         <li><a href="https://github.com/dhis2/d2-i18n-extract">d2-i18n-extract</a>, <a href="https://github.com/dhis2/d2-i18n-generate">d2-i18n-generate</a> - <strong>DEPRECATED</strong>, use <a href="https://platform.dhis2.nu">App Platform</a> instead</li>
     </ul>


### PR DESCRIPTION
This moves ui-core and ui-widgets to the deprecated area, and adds a link to ui. I've also taken the liberty of removing some commented out code, that I assume was a placeholder, and will open an issue for it to function as a reminder (which seems more appropriate to me than a comment, as that could be easily overlooked/forgotten).