### PR TITLE
fix(events): fix syntax by removing percent sign

### DIFF
--- a/archive/dates/2019-12.md
+++ b/archive/dates/2019-12.md
@@ -1,0 +1,8 @@
+---
+layout: archive
+permalink: '2019/12/'
+redirect_from: 'archive/2019/12/'
+title: 'December 2019'
+year: '2019'
+month: '12'
+---

--- a/archive/dates/2020-05.md
+++ b/archive/dates/2020-05.md
@@ -1,0 +1,8 @@
+---
+layout: archive
+permalink: '2020/05/'
+redirect_from: 'archive/2020/05/'
+title: 'May 2020'
+year: '2020'
+month: '05'
+---

--- a/archive/dates/2020.md
+++ b/archive/dates/2020.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: '2020/'
+redirect_from: 'archive/2020/'
+title: '2020'
+year: '2020'
+---

--- a/archive/tags/deprecation.md
+++ b/archive/tags/deprecation.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/deprecation/'
+redirect_from: 'archive/tags/deprecation/'
+title: 'deprecation'
+tag: 'deprecation'
+---

--- a/archive/tags/libraries.md
+++ b/archive/tags/libraries.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/libraries/'
+redirect_from: 'archive/tags/libraries/'
+title: 'libraries'
+tag: 'libraries'
+---

--- a/archive/tags/ui-core.md
+++ b/archive/tags/ui-core.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/ui-core/'
+redirect_from: 'archive/tags/ui-core/'
+title: 'ui-core'
+tag: 'ui-core'
+---

--- a/archive/tags/ui-forms.md
+++ b/archive/tags/ui-forms.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/ui-forms/'
+redirect_from: 'archive/tags/ui-forms/'
+title: 'ui-forms'
+tag: 'ui-forms'
+---

--- a/archive/tags/ui-widgets.md
+++ b/archive/tags/ui-widgets.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/ui-widgets/'
+redirect_from: 'archive/tags/ui-widgets/'
+title: 'ui-widgets'
+tag: 'ui-widgets'
+---

--- a/archive/tags/ui.md
+++ b/archive/tags/ui.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/ui/'
+redirect_from: 'archive/tags/ui/'
+title: 'ui'
+tag: 'ui'
+---

--- a/archive/tags/webapp.md
+++ b/archive/tags/webapp.md
@@ -1,0 +1,7 @@
+---
+layout: archive
+permalink: 'tags/webapp/'
+redirect_from: 'archive/tags/webapp/'
+title: 'webapp'
+tag: 'webapp'
+---

--- a/events.md
+++ b/events.md
@@ -3,14 +3,14 @@ title: Events
 layout: page
 ---
 
-{% capture now %}{{'now' | date: '%s' | plus: 0 %}}{% endcapture %}
+{% capture now %}{{'now' | date: '%s' | plus: 0 }}{% endcapture %}
 
 The DHIS2 Core Team is hosting a series training and community events, find more information at the links below:
 
 ### Upcoming events
 
 {% for event in site.data.events %}
-{% capture date %}{{event.date | date: '%s' | plus: 0 %}}{% endcapture %}
+{% capture date %}{{event.date | date: '%s' | plus: 0 }}{% endcapture %}
 {% if date > now %}
 
 {% include event.md event=event %}
@@ -23,7 +23,7 @@ The DHIS2 Core Team is hosting a series training and community events, find more
 ### Past events
 
 {% for event in reversed_events %}
-{% capture date %}{{event.date | date: '%s' | plus: 0 %}}{% endcapture %}
+{% capture date %}{{event.date | date: '%s' | plus: 0 }}{% endcapture %}
 {% if date < now %}
 
 {% include event.md event=event %}


### PR DESCRIPTION
@varl mentioned that some tags/dates were broken on the site (https://dhis2.slack.com/archives/C0BP0RABF/p1592906483377100). I noticed a syntax error while building a while back:

<img width="819" alt="Screenshot 2020-06-23 at 16 23 49" src="https://user-images.githubusercontent.com/7355199/85415966-3943dc00-b56e-11ea-99bc-3d508aacc518.png">

I initially thought that that lead to the missing pages Viktor mentioned. But when running `npm run build` and then `npm start` on `master`, `tags/ui`, `/2020` and `/2020/05` are still served without problems. So not sure what the issue is.

Regardless, this fixes the syntax and adds the missing pages. Maybe as a followup we should removed the generated pages from `/archive`, it confuses me a bit that they're in version control even though they're generated.