### PR TITLE
chore: adds Aaron Rosenberg (veganpolice) as member

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -42,3 +42,8 @@ martin:
     name: Martin Ohlson
     github: martinkrulltott
     blurb: Front-end Engineer
+
+aaron:
+    name: Aaron Rosenberg
+    github: veganpolice
+    blurb: Contributor


### PR DESCRIPTION
Following the contribution guide, this pull request adds Aaron Rosenberg as a member. 